### PR TITLE
Fix order of returned results in data loaders

### DIFF
--- a/src/loaders/createLoaders.ts
+++ b/src/loaders/createLoaders.ts
@@ -15,6 +15,7 @@ import { ModelDocument } from '../mongo/Model'
 import { NoteDocument } from '../mongo/Note'
 import { TemplateDocument } from '../mongo/Template'
 import { mongoIdCacheKeyFn } from './mongoIdCacheKeyFn'
+import { normalizeResults } from './normalizeResults'
 
 export interface Loaders {
   deckLoader: DataLoader<Types.ObjectId, DeckDocument>
@@ -33,21 +34,35 @@ export function createLoaders(user?: Express.User): Loaders {
   return {
     deckLoader: new DataLoader(
       (deckIds) => {
-        return DeckModel.find({
-          _id: { $in: Array.from(deckIds) },
-          ownerId: user?._id,
-        })
+        return normalizeResults(
+          deckIds,
+          DeckModel.find({
+            _id: { $in: Array.from(deckIds) },
+            ownerId: user?._id,
+          }),
+          '_id',
+          mongoIdCacheKeyFn
+        )
       },
       { cacheKeyFn: mongoIdCacheKeyFn }
     ),
     deckBySlugLoader: new DataLoader((slugs) => {
-      return DeckModel.find({
-        slug: { $in: Array.from(slugs) },
-        ownerId: user?._id,
-      })
+      return normalizeResults(
+        slugs,
+        DeckModel.find({
+          slug: { $in: Array.from(slugs) },
+          ownerId: user?._id,
+        }),
+        'slug'
+      )
     }),
     fieldLoader: new DataLoader((fieldIds) => {
-      return FieldModel.find({ _id: { $in: Array.from(fieldIds) } })
+      return normalizeResults(
+        fieldIds,
+        FieldModel.find({ _id: { $in: Array.from(fieldIds) } }),
+        '_id',
+        mongoIdCacheKeyFn
+      )
     }),
     fieldsByModelLoader: new DataLoader(
       async (modelIds) => {
@@ -65,10 +80,15 @@ export function createLoaders(user?: Express.User): Loaders {
     ),
     modelLoader: new DataLoader(
       (modelIds) => {
-        return ModelModel.find({
-          _id: { $in: Array.from(modelIds) },
-          ownerId: user?._id,
-        })
+        return normalizeResults(
+          modelIds,
+          ModelModel.find({
+            _id: { $in: Array.from(modelIds) },
+            ownerId: user?._id,
+          }),
+          '_id',
+          mongoIdCacheKeyFn
+        )
       },
       { cacheKeyFn: mongoIdCacheKeyFn }
     ),
@@ -89,19 +109,29 @@ export function createLoaders(user?: Express.User): Loaders {
     ),
     templateLoader: new DataLoader(
       (templateIds) => {
-        return TemplateModel.find({
-          _id: { $in: Array.from(templateIds) },
-          ownerId: user?._id,
-        })
+        return normalizeResults(
+          templateIds,
+          TemplateModel.find({
+            _id: { $in: Array.from(templateIds) },
+            ownerId: user?._id,
+          }),
+          '_id',
+          mongoIdCacheKeyFn
+        )
       },
       { cacheKeyFn: mongoIdCacheKeyFn }
     ),
     noteLoader: new DataLoader(
       (noteIds) => {
-        return NoteModel.find({
-          _id: { $in: Array.from(noteIds) },
-          ownerId: user?._id,
-        })
+        return normalizeResults(
+          noteIds,
+          NoteModel.find({
+            _id: { $in: Array.from(noteIds) },
+            ownerId: user?._id,
+          }),
+          '_id',
+          mongoIdCacheKeyFn
+        )
       },
       { cacheKeyFn: mongoIdCacheKeyFn }
     ),

--- a/src/loaders/normalizeResults.ts
+++ b/src/loaders/normalizeResults.ts
@@ -1,0 +1,33 @@
+import { Document } from 'mongoose'
+
+// Adapted from https://github.com/entria/graphql-mongoose-loader/blob/master/src/MongooseLoader.ts
+// which is MIT licensed
+
+function indexResults<T extends Document, K extends keyof T>(
+  results: T[],
+  indexField: K,
+  cacheKeyFn: (value: T[K]) => string
+) {
+  const indexedResults = new Map<string, T>()
+  results.forEach((res) => {
+    indexedResults.set(cacheKeyFn(res[indexField]), res)
+  })
+  return indexedResults
+}
+
+export async function normalizeResults<T extends Document, K extends keyof T>(
+  keys: ReadonlyArray<T[K]>,
+  resultsPromise: T[] | PromiseLike<T[]>,
+  indexField: K,
+  cacheKeyFn: (value: T[K]) => string = (value: T[K]) =>
+    (value as any).toString()
+) {
+  const results = await resultsPromise
+
+  const indexedResults = indexResults(results, indexField, cacheKeyFn)
+
+  return keys.map(
+    (val) =>
+      indexedResults.get(cacheKeyFn(val)) ?? new Error(`Key not found : ${val}`)
+  )
+}


### PR DESCRIPTION
This fixes a bug in the client where some notes in the notes table would show with the incorrect model and without any text