### PR TITLE
Move flashCards flatMap to mongodb aggregate

### DIFF
--- a/src/resolvers/deck/types.ts
+++ b/src/resolvers/deck/types.ts
@@ -210,11 +210,9 @@ export const DeckType = new GraphQLObjectType<DeckDocument, Context>({
       type: GraphQLNonNull(GraphQLInt),
       description: 'Number of flashCards in this deck',
       resolve: (root, _, ctx) =>
-        ctx.notesByDeckLoader
+        ctx.flashCardsByDeckLoader
           .load(root._id)
-          .then((notes) =>
-            notes.reduce((total, note) => total + note.flashCards.length, 0)
-          ),
+          .then((flashCards) => flashCards.length),
     },
   }),
 })


### PR DESCRIPTION
This change makes the query for the flashcards much faster, because the
bottleneck in the current implementation is the flatMap operation we are
doing on the note's flashcards.

By moving this "flatMap" to the database, it can use whatever
optimizations they have in place to make it faster. On a deck with 2K
notes and 8K flashcards, it changed from ~1.3 seconds to ~30 milliseconds
to execute the query.