### PR TITLE
Add support for anonymous user login

### DIFF
--- a/src/middlewares/auth.ts
+++ b/src/middlewares/auth.ts
@@ -2,17 +2,18 @@ import createStore from 'connect-redis'
 import type { IRouter } from 'express'
 import session from 'express-session'
 import passport from 'passport'
-import { Strategy } from 'passport-local'
+import { Strategy as LocalStrategy } from 'passport-local'
 import redis from 'redis'
 
 import config from '../config'
+import { AnonymousStrategy } from '../modules/anonymousStrategy'
 import type { UserDocument } from '../mongo/User'
 import UserModel from '../mongo/User'
 
 const RedisStore = createStore(session)
 
 passport.use(
-  new Strategy(async (username: string, password: string, done) => {
+  new LocalStrategy(async (username: string, password: string, done) => {
     let user = null
 
     try {
@@ -35,6 +36,8 @@ passport.use(
     return done(null, user)
   })
 )
+
+passport.use(new AnonymousStrategy())
 
 passport.serializeUser((user: UserDocument, done) => {
   done(null, user._id)

--- a/src/middlewares/io.ts
+++ b/src/middlewares/io.ts
@@ -6,5 +6,6 @@ export default {
   set: (app: IRouter) => {
     app.use(cookieParser())
     app.use(bodyParser.json())
+    app.use(bodyParser.urlencoded({ extended: false }))
   },
 }

--- a/src/modules/anonymousStrategy.ts
+++ b/src/modules/anonymousStrategy.ts
@@ -1,0 +1,35 @@
+import type { Request } from 'express'
+import { Strategy } from 'passport'
+import { v4 } from 'uuid'
+
+import UserModel from '../mongo/User'
+
+export class AnonymousStrategy extends Strategy {
+  name = 'anonymous'
+
+  authenticate(req: Request) {
+    const username = v4()
+
+    const zoneInfo = req.body.zoneInfo ?? 'UTC'
+    const locale = req.body.locale ?? 'en'
+
+    const anonymousUser = new UserModel({
+      username: `anon${username}`,
+      anonymous: true,
+      email: `anonymous+${username}@cramkle.com`,
+      password: '',
+      preferences: { zoneInfo, locale },
+    })
+
+    anonymousUser
+      .hashifyAndSave()
+      .then((savedUser) => {
+        this.success(savedUser)
+      })
+      .catch((err) => {
+        console.error(err)
+
+        this.fail(500)
+      })
+  }
+}

--- a/src/resolvers/user/types.ts
+++ b/src/resolvers/user/types.ts
@@ -63,5 +63,9 @@ export const UserType = new GraphQLObjectType<UserDocument>({
       type: GraphQLNonNull(UserPreferencesType),
       resolve: (user) => user.preferences ?? {},
     },
+    anonymous: {
+      type: GraphQLNonNull(GraphQLBoolean),
+      resolve: (user) => user.anonymous ?? false,
+    },
   },
 })

--- a/src/routes/auth.ts
+++ b/src/routes/auth.ts
@@ -16,6 +16,10 @@ router.post('/login', authenticate('local'), (req, res) => {
   )
 })
 
+router.post('/anonymousLogin', authenticate('anonymous'), (_, res) => {
+  res.redirect('/')
+})
+
 router.post('/logout', (req, res) => {
   req.logout()
   res.json({ ok: true })


### PR DESCRIPTION
This PR adds the route `/_c/auth/anonymousLogin` where we will create an anonymous user and a login session for this newly created user. I also modified the `updateProfile` mutation to handle the anonymous user case, which will return a 400 status code error when any of the username, email or password are not send in the arguments.