### PR TITLE
No duplicate deck install from marketplace

### DIFF
--- a/src/resolvers/deck/listDecks.ts
+++ b/src/resolvers/deck/listDecks.ts
@@ -60,7 +60,7 @@ export const publishedDecks: GraphQLFieldConfig<
   Context,
   PageConnectionArgs
 > = {
-  type: deckConnection.connectionType,
+  type: GraphQLNonNull(deckConnection.connectionType),
   description: 'Retrieve all published decks',
   args: {
     page: { type: GraphQLNonNull(GraphQLInt), defaultValue: 1 },

--- a/src/resolvers/deck/types.ts
+++ b/src/resolvers/deck/types.ts
@@ -126,6 +126,16 @@ export const DeckType: GraphQLObjectType = new GraphQLObjectType<
       description: 'Original deck',
       resolve: (root) => DeckModel.findById(root.originalDeckId),
     },
+    isDeckInstalled: {
+      type: GraphQLNonNull(GraphQLBoolean),
+      description: 'Whether this deck is already installed for current user',
+      resolve: (root, _, { user }) =>
+        root.published &&
+        DeckModel.findOne({
+          originalDeckId: root._id,
+          ownerId: user!._id,
+        }).then((deck) => deck != null),
+    },
     published: {
       type: GraphQLNonNull(GraphQLBoolean),
       description: 'Whether this deck is published to the marketplace',

--- a/src/resolvers/user/__tests__/createUser.test.ts
+++ b/src/resolvers/user/__tests__/createUser.test.ts
@@ -25,7 +25,7 @@ describe('CreateUser mutation', () => {
 
     expect(result.createUser.user.id).toStrictEqual(expect.any(String))
     expect(result.createUser.user.username).toBe('lucas')
-    expect(result.createUser.user.email).toBe('lucas@email.com')
+    expect(result.createUser.user.email).toBeNull()
   })
 
   it('createUser errors on duplicated usernames', async () => {
@@ -59,7 +59,7 @@ describe('CreateUser mutation', () => {
 
     expect(result.createUser.user.id).toStrictEqual(expect.any(String))
     expect(result.createUser.user.username).toBe('myuser')
-    expect(result.createUser.user.email).toBe('user_email@email.com')
+    expect(result.createUser.user.email).toBeNull()
 
     const secondResult = await runQuery(query)
 

--- a/src/resolvers/user/types.ts
+++ b/src/resolvers/user/types.ts
@@ -50,15 +50,37 @@ export const UserType = new GraphQLObjectType<UserDocument>({
       description: "User's username",
     },
     email: {
-      type: GraphQLNonNull(GraphQLString),
+      type: GraphQLString,
       description: "User's email",
+      resolve: (root, _, { user }) => {
+        if (root._id !== user?._id) {
+          return null
+        }
+
+        return root.email
+      },
     },
     roles: {
-      type: GraphQLNonNull(GraphQLList(GraphQLNonNull(UserRolesEnumType))),
+      type: GraphQLList(GraphQLNonNull(UserRolesEnumType)),
+      resolve: (root, _, { user }) => {
+        if (root._id !== user?._id) {
+          return null
+        }
+
+        return root.email
+      },
     },
     preferences: {
-      type: GraphQLNonNull(UserPreferencesType),
-      resolve: (user) => user.preferences ?? {},
+      type: UserPreferencesType,
+      resolve: (root, _, user) => {
+        if (root._id !== user?._id) {
+          return null
+        }
+
+        const preferences = root.preferences ?? {}
+
+        return preferences
+      },
     },
     anonymous: {
       type: GraphQLNonNull(GraphQLBoolean),


### PR DESCRIPTION
- Secure sensitive user information
- Forbid re-publishing decks from marketplace
- Add field to indicate whether a deck is already installed
- Bail from installing deck more than once
